### PR TITLE
modules: add node-drone-joystick to "modules" page

### DIFF
--- a/pages/modules.md
+++ b/pages/modules.md
@@ -23,3 +23,4 @@ page](https://github.com/nodecopter/nodecopter.com/edit/master/pages/modules.md)
 * [nodecopter-tennis](https://github.com/arjaneising/nodecopter-tennis): Use your drone as a tennis ball!
 * [ipad-ardrone-controller](https://github.com/createdotnet/ipad-ardrone-controller):Control your drone with an iPad and gestures.
 * [qrar](https://npmjs.org/package/qrar): Decode QR codes found by your drone.
+* [node-drone-joystick](https://github.com/TooTallNate/node-drone-joystick): Control AR.Drones using any SDL-compatible Joystick (PS3 Sixaxis, etc.)


### PR DESCRIPTION
Added a link to my `node-drone-joystick` project for controlling the drone using a PS3 (among other SDL-compatible joysticks) controller.
