### PR TITLE
Added instructions to connect the drone to WPA network

### DIFF
--- a/guides/connect_to_access_point.md
+++ b/guides/connect_to_access_point.md
@@ -9,13 +9,20 @@ Normally, if you're connected to your drone's WiFi you don't have connection to
 the internet. This is not very convenient, so an easy way out is letting the AR drone
 connect to a WiFi accesspoint.
 
-Please note that this only works for open networks, so no WPA or similar.
+**Connect to an open network**
+
+If you have access to an open network (no WPA or similar), you can simply:
 
 * Telnet into the drone: `telnet 192.168.1.1`
 * Execute the following command (replacing [ssid] and [wanted ip] with their values):
 
 `killall udhcpd; iwconfig ath0 mode managed essid [ssid]; ifconfig ath0 [wanted ip] netmask 255.255.255.0 up;`
 
-## Thanks
-
 Thank you [@karlwestin](http://twitter.com/karlwestin) for [this gist](https://gist.github.com/karlwestin/4051467).
+
+**Connect to a network secured with WPA**
+
+In order to connect to a secure network, you need to install WPA support on your drone. The good news is that
+[@daraosn](http://twitter.com/daraosn) took the time to cross-compile wpa_supplicant and write some handy install scripts.
+
+Just checkout the [ardrone-wpa2](https://github.com/daraosn/ardrone-wpa2) repo on githbub and follow the instructions there.


### PR DESCRIPTION
It took me a while to find out about this wpa_supplicant to connect the drone to my own access point. It would be good to add a pointer to the instructions on the website. I've added a link to https://github.com/daraosn/ardrone-wpa2 project on the page.
