### PR TITLE
Remove deprecatated options from README & _config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ gem install jekyll
 You can now run the site locally on port 4000 using:
 
 ```bash
-jekyll --auto --server
+jekyll serve --watch
 ```
 
 ## Deployment

--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,4 @@ exclude:
   - README.md
   - CONTRIBUTING.md
 markdown: redcarpet
-pygments: true
+highlighter: pygments


### PR DESCRIPTION
Updated the `README` to run the site up locally with the correct options for jekyll version 2.0.3. Also changed the `_config.yml` file to do pygments right since `pygments: true` is deprecated.
