### PR TITLE
Fix kramdown code blocks

### DIFF
--- a/hack.md
+++ b/hack.md
@@ -115,7 +115,7 @@ the drone's WiFi with your laptop and install the [ar-drone](https://github.com/
 
 Once you've done that, save this to a file:
 
-```javascript
+~~~javascript
 var arDrone = require('ar-drone');
 var client = arDrone.createClient();
 
@@ -132,7 +132,7 @@ client
     this.stop();
     this.land();
   });
-```
+~~~
 
 and execute it. See how your drone takes of, rotates clockwise and even does a flip!
 Amazing. Now you're set, go ahead and get crazy!

--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ Install [Node.js](http://nodejs.org) and get the
 to execute the following code with node. That will make your drone take off,
 move around, do a flip and carefully land again. Seriously, that's all!
 
-```
+~~~javascript
 var arDrone = require('ar-drone');
 var client = arDrone.createClient();
 
@@ -96,4 +96,4 @@ client
     this.stop();
     this.land();
   });
-```
+~~~


### PR DESCRIPTION
The change to kramdown 31528e6bb10f4273671e11c6fcdd74efcc8e4e1b breaks redcarpet code blocks, i.e., no syntax highlighting.
